### PR TITLE
Remove need for `toValue` syntax on simple expand methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     commonSettings,
     name := "uritemplate4s",
     testFrameworks += new TestFramework("utest.runner.Framework"),
+    sourceGenerators in Compile += (sourceManaged in Compile).map(Boilerplate.gen).taskValue,
     doctestTestFramework := DoctestTestFramework.MicroTest,
     libraryDependencies ++= Seq(
       "com.lihaoyi" %%% "fastparse" % fastparseVersion

--- a/core/jvm/src/test/scala/uritemplate4s/ExternalTests.scala
+++ b/core/jvm/src/test/scala/uritemplate4s/ExternalTests.scala
@@ -65,7 +65,7 @@ object ExternalTests extends TestSuite {
       (template, expectedResult) <- testcases
     } yield {
       def result =
-        UriTemplate.parse(template).flatMap(_.expand(variables.value.toVector: _*).toEither)
+        UriTemplate.parse(template).flatMap(_.expandVars(variables.value.toVector: _*).toEither)
       expectedResult match {
         case Expected(expectedValue) =>
           assert(result == Right(expectedValue))

--- a/core/shared/src/main/scala/uritemplate4s/UriTemplate.scala
+++ b/core/shared/src/main/scala/uritemplate4s/UriTemplate.scala
@@ -4,18 +4,20 @@ import fastparse.all.Parsed
 import uritemplate4s.ListSyntax._
 import uritemplate4s.UriTemplate._
 
-trait UriTemplate {
+trait UriTemplateBase {
   /**
     * Expand the parsed URI Template using the supplied vars.
     * @param vars name value pairs to be substituted in the template.
     * @return the expanded template.
     */
-  def expand(vars: (String, Value)*): Result
+  def expandVars(vars: (String, Value)*): Result
 }
+
+trait UriTemplate extends UriTemplateBase with UriTemplateArities
 
 private final class ComponentsUriTemplate(components: List[Component]) extends UriTemplate {
 
-  override def expand(vars: (String, Value)*): Result = {
+  override def expandVars(vars: (String, Value)*): Result = {
     lazy val varsMap = vars.toMap
 
     val errorsAndLiteralsList: List[(List[ExpandError], List[Literal])] = for {

--- a/core/shared/src/main/scala/uritemplate4s/UriTemplate.scala
+++ b/core/shared/src/main/scala/uritemplate4s/UriTemplate.scala
@@ -4,7 +4,7 @@ import fastparse.all.Parsed
 import uritemplate4s.ListSyntax._
 import uritemplate4s.UriTemplate._
 
-trait UriTemplateBase {
+private[uritemplate4s] trait UriTemplateBase {
   /**
     * Expand the parsed URI Template using the supplied vars.
     * @param vars name value pairs to be substituted in the template.

--- a/core/shared/src/test/scala/uritemplate4s/UriTemplateTests.scala
+++ b/core/shared/src/test/scala/uritemplate4s/UriTemplateTests.scala
@@ -12,7 +12,7 @@ object UriTemplateTests extends TestSuite {
                   ): Unit = {
     val varList = vars.toList
     testCases.foreach { case (template, exp) =>
-      val actual = UriTemplate.parse(template).flatMap(_.expand(varList: _*).toEither)
+      val actual = UriTemplate.parse(template).flatMap(_.expandVars(varList: _*).toEither)
       assert(Right(exp) == actual)
     }
   }

--- a/docs/src/main/scala/uritemplate4s/demo/Playground.scala
+++ b/docs/src/main/scala/uritemplate4s/demo/Playground.scala
@@ -104,7 +104,7 @@ object Playground {
         val result = for {
           template <- templateE.leftMap(_.message)
           values <- valuesE.leftMap(_.getMessage)
-          result <- template.expand(values: _*)
+          result <- template.expandVars(values: _*)
             .toEither.leftMap(_.message)
         } yield result
         result.merge

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -10,7 +10,7 @@ object Boilerplate {
       |import syntax._
       |import UriTemplate.Result
       |
-      |trait UriTemplateArities extends UriTemplateBase {
+      |private[uritemplate4s] trait UriTemplateArities extends UriTemplateBase {
       |${methods.split("\n").map(method => s"  $method").mkString("\n")}
       |}
     """.stripMargin

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -1,0 +1,33 @@
+import sbt._
+
+object Boilerplate {
+
+  private def template(methods: String) =
+    s"""
+      |// auto-generated boilerplate, see package/Boilerplate.scala
+      |package uritemplate4s
+      |
+      |import syntax._
+      |import UriTemplate.Result
+      |
+      |trait UriTemplateArities extends UriTemplateBase {
+      |${methods.split("\n").map(method => s"  $method").mkString("\n")}
+      |}
+    """.stripMargin
+
+  private val content = template(
+    (1 to 22).map { numArities =>
+      val range = 1 to numArities
+      val genericTypes = range.map(i => s"A$i : ToValue").mkString(", ")
+      val args = range.map(i => s"a$i: (String, A$i)").mkString(", ")
+      val params = range.map(i => s"a$i._1 -> a$i._2.toValue").mkString(", ")
+      s"def expand[$genericTypes]($args): Result = expandVars($params)"
+    }.mkString("\n")
+  )
+
+  def gen(dir: File): List[File] = {
+    val path = dir / "uritemplate4s" / "UriTemplateArities.scala"
+    IO.write(path, content)
+    List(path)
+  }
+}


### PR DESCRIPTION
Unlikely someone will ever need more than 22 variables for a template anyway.