### PR TITLE
0-arity expand

### DIFF
--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -15,13 +15,13 @@ object Boilerplate {
     """.stripMargin
 
   private val content = template(
-    (1 to 22).map { numArities =>
+    ("def expand(): ExpandResult = expandVars()" :: (1 to 22).toList.map { numArities =>
       val range = 1 to numArities
       val genericTypes = range.map(i => s"A$i : ToValue").mkString(", ")
       val args = range.map(i => s"a$i: (String, A$i)").mkString(", ")
       val params = range.map(i => s"a$i._1 -> a$i._2.toValue").mkString(", ")
       s"def expand[$genericTypes]($args): ExpandResult = expandVars($params)"
-    }.mkString("\n")
+    }).mkString("\n")
   )
 
   def gen(dir: File): List[File] = {


### PR DESCRIPTION
This is for cases where no arguments are needed,
i.e. in the GitHub API a template is specified `https://api.github.com/repos/typelevel/cats-effect/pulls{/number}`, number should be able to be omitted leaving `https://api.github.com/repos/typelevel/cats-effect/pulls`.